### PR TITLE
Upstream Fixes

### DIFF
--- a/fastboot/Android.mk
+++ b/fastboot/Android.mk
@@ -62,7 +62,7 @@ ifneq ($(HOST_OS),windows)
 LOCAL_STATIC_LIBRARIES += libselinux
 endif # HOST_OS != windows
 
-ifeq ($(HOST_OS),linux)
+ifneq (,$(filter linux darwin,$(HOST_OS)))
 # libf2fs_dlutils_host will dlopen("libf2fs_fmt_host_dyn")
 LOCAL_CFLAGS += -DUSE_F2FS
 LOCAL_LDFLAGS += -ldl -rdynamic -Wl,-rpath,.
@@ -75,7 +75,7 @@ endif
 include $(BUILD_HOST_EXECUTABLE)
 
 my_dist_files := $(LOCAL_BUILT_MODULE)
-ifeq ($(HOST_OS),linux)
+ifneq (,$(filter linux darwin,$(HOST_OS)))
 my_dist_files += $(HOST_LIBRARY_PATH)/libf2fs_fmt_host_dyn$(HOST_SHLIB_SUFFIX)
 endif
 $(call dist-for-goals,dist_files sdk,$(my_dist_files))

--- a/fs_mgr/fs_mgr_format.c
+++ b/fs_mgr/fs_mgr_format.c
@@ -67,15 +67,27 @@ static int format_ext4(char *fs_blkdev, char *fs_mnt_point, long long fs_length)
     return rc;
 }
 
-static int format_f2fs(char *fs_blkdev)
+static int format_f2fs(char *fs_blkdev, long long fs_length)
 {
-    char * args[3];
+    char * args[5];
     int pid;
     int rc = 0;
+    char buff[65];
 
     args[0] = (char *)"/sbin/mkfs.f2fs";
-    args[1] = fs_blkdev;
-    args[2] = (char *)0;
+
+    if (fs_length >= 0) {
+        snprintf(buff, sizeof(buff), "%lld", fs_length / 512);
+        args[1] = fs_blkdev;
+        args[2] = buff;
+        args[3] = (char *)0;
+    } else if (fs_length < 0) {
+        snprintf(buff, sizeof(buff), "%lld", -fs_length);
+        args[1] = "-r";
+        args[2] = buff;
+        args[3] = fs_blkdev;
+        args[4] = (char *)0;
+    }
 
     pid = fork();
     if (pid < 0) {
@@ -114,7 +126,7 @@ int fs_mgr_do_format(struct fstab_rec *fstab)
     ERROR("%s: Format %s as '%s'.\n", __func__, fstab->blk_device, fstab->fs_type);
 
     if (!strncmp(fstab->fs_type, "f2fs", 4)) {
-        rc = format_f2fs(fstab->blk_device);
+        rc = format_f2fs(fstab->blk_device, fstab->length);
     } else if (!strncmp(fstab->fs_type, "ext4", 4)) {
         rc = format_ext4(fstab->blk_device, fstab->mount_point, fstab->length);
     } else {

--- a/libsysutils/src/NetlinkEvent.cpp
+++ b/libsysutils/src/NetlinkEvent.cpp
@@ -610,6 +610,6 @@ const char *NetlinkEvent::findParam(const char *paramName) {
             return ++ptr;
     }
 
-    SLOGE("NetlinkEvent::FindParam(): Parameter '%s' not found", paramName);
+    SLOGV("NetlinkEvent::FindParam(): Parameter '%s' not found", paramName);
     return NULL;
 }

--- a/libsysutils/src/NetlinkEvent.cpp
+++ b/libsysutils/src/NetlinkEvent.cpp
@@ -584,6 +584,10 @@ bool NetlinkEvent::parseAsciiNetlinkMessage(char *buffer, int size) {
         }
         s += strlen(s) + 1;
     }
+    if(findParam("ALERT_NAME") !=NULL ) {
+        mSubsystem = strdup("qlog");
+        mAction = NlActionChange;
+    }
     return true;
 }
 

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -62,6 +62,7 @@ on init
     write /sys/fs/cgroup/memory/sw/memory.move_charge_at_immigrate 1
     chown root system /sys/fs/cgroup/memory/sw/tasks
     chmod 0660 /sys/fs/cgroup/memory/sw/tasks
+    chmod 0220 /sys/fs/cgroup/memory/cgroup.event_control
 
     mkdir /system
     mkdir /data 0771 system system


### PR DESCRIPTION
IPA tether: support for netlink event from ipa
Don't use global variable in libnetutils.
sysutils: Hush logging
init.rc: drop world writable on cgroups to pass cts
fs_mgr: When formating f2fs volumes, respect the length parameter
fastboot: format f2fs partition instead of just erase
